### PR TITLE
Add a listener and deserialise success/error messages so user can be notified on completion.

### DIFF
--- a/androidmandrillinterface/src/main/AndroidManifest.xml
+++ b/androidmandrillinterface/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="net.soroushjavdan.androidmandrillinterface" >
     <application
-        android:allowBackup="true"
         android:label="@string/app_name" ></application>
 
 </manifest>


### PR DESCRIPTION
In my project we need to notify the user when the email send has completed. Also this lets us detect the success/failure state of the mandrill API call.

Removing `allowBackup` avoids conflicts when this library is added to a project that sets allowBackup to false. Note that the value defaults to true anyway.